### PR TITLE
Add mention of provider registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,20 @@ Follow these steps to get started.
     cd remote-auth-mcp-apim-py
     ```
 
-4. Log in to Azure Developer CLI:
+4. Ensure the `Microsoft.App` resource provider is registered on your subscription either on the [Azure portal](https://learn.microsoft.com/azure/azure-resource-manager/management/resource-providers-and-types#azure-portal) or by running the following [Azure CLI command](https://learn.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest):
+
+    ```bash
+    az login
+    az provider register --namespace Microsoft.App --wait
+    ```
+
+5. Log in to Azure Developer CLI:
 
     ```bash
     azd auth login
     ```
 
-5. Deploy the project to Azure:
+6. Deploy the project to Azure:
 
     ```bash
     azd up


### PR DESCRIPTION
## Purpose

If the `Microsoft.App` provider is not registered on the subscription the deployment error out with the following message:

```
Deployment Error Details:
Unauthorized: The ServiceAssociationLink (SAL) related operation failed with error 'Unable to integrate function app [func-api-XX] with subnet [/subscriptions/XXX/resourceGroups/rg-localden-XXX/virtualNetworks/vnet-X/subnets/app] due to error: [Please check if 'Microsoft.App' is registered as a resource provider in your subscription.
You may check Resource Providers in the Azure Portal or in Azure Cloud Shell as: `Get-AzResourceProvider -ProviderNamespace Microsoft.App`.
You can register provider in Azure Portal or in Azure Cloud Shell as: `Register-AzResourceProvider -ProviderNamespace Microsoft.App`
...
```
This is most likely due to the [subnet delegation for Azure Functions](https://github.com/localden/remote-auth-mcp-apim-py/blob/4723150ff2f22ed5f0b25bcb32dd596c43d2dfbb/infra/app/vnet.bicep#L56)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Run `azd up` on a new subscription, witness the error highlighted above
* Run the suggest command line
* Run `azd up` again and witness the deployment now succeed

* Test the code
N/A, no code changes

## What to Check
N/A

## Other Information
<!-- Add any other helpful information that may be needed here. -->